### PR TITLE
Fixed typo.

### DIFF
--- a/_posts/2019-10-31-harfbuzz-libxml2-libssh-gnutls.md
+++ b/_posts/2019-10-31-harfbuzz-libxml2-libssh-gnutls.md
@@ -6,7 +6,7 @@ title: Harfbuzz, libxml2, libssh, GnuTLS updates
 The following projects have been updated:
 * Harfbuzz was updated to 2.6.2 then 2.6.3 then to 2.6.4.
 * libxml2 was updated to 2.9.10.
-* libssh2 was updated to 0.9.1.
+* libssh was updated to 0.9.1.
 * libcdio-paranoia was updated to 10.2+2.0.1.
 * GnuTLS was updated to 3.6.10.
 


### PR DESCRIPTION
Fixed typo. It's libssh (libssh2 is a different library).